### PR TITLE
Silence the warnings on restart

### DIFF
--- a/bin/qrunner
+++ b/bin/qrunner
@@ -164,6 +164,12 @@ def main():
     except getopt.error as msg:
         usage(1, msg)
 
+    def silent_unraisable_hook(unraisable):
+        pass
+
+    if hasattr(sys, 'unraisablehook'):
+        sys.unraisablehook = silent_unraisable_hook
+
     once = 0
     runners = []
     verbose = 0


### PR DESCRIPTION
Case HB-8126:
Silence the warnings that occurred when the qrunners restart about the ignored exception in TextIOWrapper about the file descriptors going away.

I'll remove the `[DO NOT MERGE YET]` title addition when the case passes internal review and testing.