### PR TITLE
Fix DMARC record handling.

### DIFF
--- a/Mailman/Utils.py
+++ b/Mailman/Utils.py
@@ -1381,7 +1381,7 @@ def _DMARCProhibited(mlist, email, dmarc_domain, org=False):
             if txt_rec.rdtype != dns.rdatatype.TXT:
                 continue
             results_by_name.setdefault(name, []).append(
-                "".join(txt_rec.items[0].strings))
+                "".join( [ record.decode() if isinstance(record, bytes) else record for record in txt_rec.items[0].strings ] ))
         expands = list(want_names)
         seen = set(expands)
         while expands:

--- a/Mailman/Utils.py
+++ b/Mailman/Utils.py
@@ -1263,6 +1263,10 @@ def get_suffixes(url):
                url, e)
         return
     for line in d.readlines():
+        if not line:
+            continue
+        if isinstance(line, bytes):
+            line = line.decode()
         if not line.strip() or line.startswith(' ') or line.startswith('//'):
             continue
         line = re.sub(' .*', '', line.strip())


### PR DESCRIPTION
Case HB-8202

DMARC records were byte strings, these needed to be decoded into utf-8 strings.

Changelog: Fix DMARC record handling.