### PR TITLE
Upgrade unpickled Message object for Python 3 compatibility.

### DIFF
--- a/Mailman/Archiver/HyperDatabase.py
+++ b/Mailman/Archiver/HyperDatabase.py
@@ -68,9 +68,20 @@ class DumbBTree(object):
 
     def __sort(self, dirty=None):
         if self.__dirty == 1 or dirty:
-            self.sorted = list(self.dict.keys())
-            self.sorted.sort()
+            self.sorted = self.__fix_for_sort(list(self.dict.keys()))
+            if hasattr(self.sorted, 'sort'):
+                self.sorted.sort()
             self.__dirty = 0
+
+    def __fix_for_sort(self, items):
+        if isinstance(items, bytes):
+            return items.decode()
+        elif isinstance(items, list):
+            return [ self.__fix_for_sort(item) for item in items ]
+        elif isinstance(items, tuple):
+            return tuple( self.__fix_for_sort(item) for item in items )
+        else:
+            return items
 
     def lock(self):
         self.lockfile.lock()

--- a/Mailman/ListAdmin.py
+++ b/Mailman/ListAdmin.py
@@ -615,6 +615,8 @@ def readMessage(path):
         else:
             assert ext == '.pck'
             msg = pickle.load(fp, fix_imports=True, encoding='latin1')
+            if not hasattr(msg, 'policy'):
+                msg.policy = email._policybase.compat32
     finally:
         fp.close()
     return msg

--- a/Mailman/Message.py
+++ b/Mailman/Message.py
@@ -241,9 +241,9 @@ class Message(email.message.Message):
         """
         fp = StringIO()
         g = Generator(fp, mangle_from_=mangle_from_)
+        Utils.set_cte_if_missing(self)
         g.flatten(self, unixfrom=unixfrom)
         return fp.getvalue()
-
 
 
 class UserNotification(Message):

--- a/Mailman/Utils.py
+++ b/Mailman/Utils.py
@@ -1654,3 +1654,10 @@ def get_current_encoding(filename):
             continue
     # if everything fails, send utf-8 and hope for the best...
     return 'utf-8'
+
+def set_cte_if_missing(msg):
+    if 'content-transfer-encoding' not in msg:
+        msg['Content-Transfer-Encoding'] = '7bit'
+    if msg.is_multipart():
+        for part in msg.get_payload():
+            set_cte_if_missing(part)


### PR DESCRIPTION
Case HB-8201: If a message is held for moderation prior to the Python 3 upgrade, the resulting pickle file will be missing a required field that email.message on Python 3 expects. This patch fills in the missing field so that messages held for moderation prior to the upgrade can still be processed.