### PR TITLE
Fix problems from old archives.

### DIFF
--- a/Mailman/Archiver/HyperDatabase.py
+++ b/Mailman/Archiver/HyperDatabase.py
@@ -68,9 +68,20 @@ class DumbBTree(object):
 
     def __sort(self, dirty=None):
         if self.__dirty == 1 or dirty:
-            self.sorted = list(self.dict.keys())
-            self.sorted.sort()
+            self.sorted = self.__fix_for_sort(list(self.dict.keys()))
+            if hasattr(self.sorted, 'sort'):
+                self.sorted.sort()
             self.__dirty = 0
+
+    def __fix_for_sort(self, items):
+        if isinstance(items, bytes):
+            return items.decode()
+        elif isinstance(items, list):
+            return [ self.__fix_for_sort(item) for item in items ]
+        elif isinstance(items, tuple):
+            return tuple( self.__fix_for_sort(item) for item in items )
+        else:
+            return items
 
     def lock(self):
         self.lockfile.lock()

--- a/Mailman/Message.py
+++ b/Mailman/Message.py
@@ -241,9 +241,9 @@ class Message(email.message.Message):
         """
         fp = StringIO()
         g = Generator(fp, mangle_from_=mangle_from_)
+        Utils.set_cte_if_missing(self)
         g.flatten(self, unixfrom=unixfrom)
         return fp.getvalue()
-
 
 
 class UserNotification(Message):

--- a/Mailman/Utils.py
+++ b/Mailman/Utils.py
@@ -1654,3 +1654,10 @@ def get_current_encoding(filename):
             continue
     # if everything fails, send utf-8 and hope for the best...
     return 'utf-8'
+
+def set_cte_if_missing(msg):
+    if 'content-transfer-encoding' not in msg:
+        msg['Content-Transfer-Encoding'] = '7bit'
+    if msg.is_multipart():
+        for part in msg.get_payload():
+            set_cte_if_missing(part)


### PR DESCRIPTION
Case HB-8200

This commit fixes three problems.

1) Some metadata about the mailing list is pickled for use during archiving a list. When this data was pickled under the previous version some of the strings could be byte strings. The new version expects all the data to be strings. We now ensure all the data from the pickle file are normal strings.

2) Under the old version, when an mbox file is written to for archiving the encoding of the last email is used for the encoding of the mbox file. After an upgrade to the new version, some of these mbox files could be non-utf8 which would cause encoding issues when we try to read the files. We now catch that error and write the file back to disk as utf8.

3) When sending an email to the list via sendmail, the messages were missing a 'content-transfer-encoding' header and caused errors when Mailman would load these messages. We now ensure messages have this header and set it to the default value if it is missing.

Changelog: Fix problems from old archives.