### PR TITLE
Move module import out of config file.

### DIFF
--- a/Mailman/__init__.py.in
+++ b/Mailman/__init__.py.in
@@ -13,3 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software 
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+import sys
+sys.path.append('@VAR_PREFIX@/Mailman')

--- a/Mailman/mm_cfg.py.dist.in
+++ b/Mailman/mm_cfg.py.dist.in
@@ -43,11 +43,9 @@ affect lists created after the change.  For existing lists, see the FAQ at
 
 """
 
-import sys
 ###############################################
 # Here's where we get the distributed defaults.
 
-sys.path.append('@VAR_PREFIX@/Mailman')
 from Defaults import *
 
 ##################################################

--- a/configure.in
+++ b/configure.in
@@ -764,7 +764,7 @@ AC_CONFIG_FILES([misc/paths.py Mailman/Defaults.py Mailman/mm_cfg.py.dist
            Mailman/Queue/Makefile Mailman/MTA/Makefile Mailman/Gui/Makefile
            templates/Makefile cron/Makefile scripts/Makefile messages/Makefile
            cron/crontab.in misc/mailman Makefile
-           tests/Makefile tests/bounces/Makefile tests/msgs/Makefile
+           tests/Makefile tests/bounces/Makefile tests/msgs/Makefile Mailman/__init__.py
            $SCRIPTS])
 AC_CONFIG_COMMANDS([default],[echo "configuration completed at" `date`],[])
 AC_OUTPUT


### PR DESCRIPTION
Case HB-8228

Having the module import inside the configuration file is a problem since we can't ensure those imports will exist in a user controlled file.

Changelog: Move module import out of config file.