### PR TITLE
Update other areas to support older Python2 Messages/email pickle files

### DIFF
--- a/Mailman/Archiver/HyperArch.py
+++ b/Mailman/Archiver/HyperArch.py
@@ -312,9 +312,11 @@ class Article(pipermail.Article):
             except binascii.Error:
                 body = None
             if body and charset != Utils.GetCharSet(self._lang):
+                if isinstance(charset, bytes):
+                    charset = charset.decode()
                 # decode body
                 try:
-                    body = str(body, charset)
+                    body = body.decode(charset)
                 except (UnicodeError, LookupError):
                     body = None
             if body:

--- a/Mailman/Archiver/HyperDatabase.py
+++ b/Mailman/Archiver/HyperDatabase.py
@@ -30,6 +30,7 @@ import errno
 #
 from . import pipermail
 from Mailman import LockFile
+from Mailman import Utils
 
 CACHESIZE = pipermail.CACHESIZE
 
@@ -297,7 +298,7 @@ class HyperDatabase(pipermail.Database):
         if msgid not in self.__cache:
             # get the pickled object out of the DumbBTree
             buf = self.articleIndex[msgid]
-            article = self.__cache[msgid] = pickle.loads(buf, fix_imports=True, encoding='latin1')
+            article = self.__cache[msgid] = Utils.load_pickle(buf)
             # For upgrading older archives
             article.setListIfUnset(self._mlist)
         else:

--- a/Mailman/Archiver/pipermail.py
+++ b/Mailman/Archiver/pipermail.py
@@ -17,6 +17,7 @@ CACHESIZE = 100    # Number of slots in the cache
 
 from Mailman import mm_cfg
 from Mailman import Errors
+from Mailman import Utils
 from Mailman.Mailbox import ArchiverMailbox
 from Mailman.Logging.Syslog import syslog
 from Mailman.i18n import _, C_
@@ -298,10 +299,8 @@ class T(object):
         try:
             if not reload:
                 raise IOError
-            f = open(os.path.join(self.basedir, 'pipermail.pck'), 'rb')
+            d = Utils.load_pickle(os.path.join(self.basedir, 'pipermail.pck'))
             self.message(C_('Reloading pickled archive state'))
-            d = pickle.load(f, fix_imports=True)
-            f.close()
             for key, value in list(d.items()):
                 setattr(self, key, value)
         except (IOError, EOFError):

--- a/Mailman/Cgi/admindb.py
+++ b/Mailman/Cgi/admindb.py
@@ -737,7 +737,6 @@ def show_post_requests(mlist, id, info, total, count, form):
                             break
                 break
     else:
-        charset = msg.get_content_charset() or 'utf-8'
         payload = msg.get_payload(decode=True)
         if payload:
             decoded_payload = codecs.decode(payload, 'unicode_escape')

--- a/Mailman/MailList.py
+++ b/Mailman/MailList.py
@@ -658,9 +658,7 @@ class MailList(HTMLFormatter, Deliverer, ListAdmin,
                 if dbfile.endswith('.db') or dbfile.endswith('.db.last'):
                     dict_retval = marshal.load(fp)
                 elif dbfile.endswith('.pck') or dbfile.endswith('.pck.last'):
-                    dict_retval = pickle.load(fp, fix_imports=True, encoding='latin1')
-#                dict_retval = loadfunc(fp)
-
+                    dict_retval = Utils.load_pickle(dbfile)
                 if not isinstance(dict_retval, dict):
                     return None, 'Load() expected to return a dictionary'
             except (EOFError, ValueError, TypeError, MemoryError,

--- a/Mailman/Mailbox.py
+++ b/Mailman/Mailbox.py
@@ -66,6 +66,8 @@ class Mailbox(mailbox.mbox):
             # Create a Generator instance to write the message to the file
             g = Generator(fileh)
             Utils.set_cte_if_missing(msg)
+            if not hasattr(msg, 'policy'):
+                msg.policy = email._policybase.compat32
             g.flatten(msg, unixfrom=True)
             # Add one more trailing newline for separation with the next message
             # to be appended to the mbox.

--- a/Mailman/Mailbox.py
+++ b/Mailman/Mailbox.py
@@ -66,8 +66,6 @@ class Mailbox(mailbox.mbox):
             # Create a Generator instance to write the message to the file
             g = Generator(fileh)
             Utils.set_cte_if_missing(msg)
-            if not hasattr(msg, 'policy'):
-                msg.policy = email._policybase.compat32
             g.flatten(msg, unixfrom=True)
             # Add one more trailing newline for separation with the next message
             # to be appended to the mbox.

--- a/Mailman/Message.py
+++ b/Mailman/Message.py
@@ -69,6 +69,8 @@ class Message(email.message.Message):
 
     # BAW: For debugging w/ bin/dumpdb.  Apparently pprint uses repr.
     def __repr__(self):
+        if not hasattr(self, 'policy'):
+            self.policy = email._policybase.compat32
         return self.__str__()
 
     def __setstate__(self, d):

--- a/Mailman/Pending.py
+++ b/Mailman/Pending.py
@@ -27,7 +27,7 @@ import pickle
 
 from Mailman import mm_cfg
 from Mailman import UserDesc
-from Mailman.Utils import sha_new
+from Mailman.Utils import sha_new, load_pickle
 
 # Types of pending records
 SUBSCRIPTION = 'S'
@@ -84,14 +84,13 @@ class Pending(object):
 
     def __load(self):
         try:
-            fp = open(self.__pendfile, 'rb')
-        except IOError as e:
-            if e.errno != errno.ENOENT: raise
+            obj = Utils.load_pickle(self.__pendfile)
+            if obj == None:
+                return {'evictions': {}}
+            else:
+                return obj
+        except Exception as e:
             return {'evictions': {}}
-        try:
-            return pickle.load(fp, fix_imports=True, encoding='latin1')
-        finally:
-            fp.close()
 
     def __save(self, db):
         evictions = db['evictions']

--- a/bin/dumpdb
+++ b/bin/dumpdb
@@ -54,6 +54,7 @@ import marshal
 import paths
 # Import this /after/ paths so that the sys.path is properly hacked
 from Mailman.i18n import C_
+from Mailman import Utils
 
 PROGRAM = sys.argv[0]
 COMMASPACE = ', '
@@ -125,7 +126,12 @@ def main():
             print(C_('[----- start %(typename)s file -----]'))
         while True:
             try:
-                obj = load(fp, encoding='latin1')
+                if typename == 'pickle':
+                    obj = Utils.load_pickle(fp)
+                    if obj is None:
+                        break
+                else:
+                    obj = load(fp, encoding='utf-8')
             except EOFError:
                 if doprint:
                     print(C_('[----- end %(typename)s file -----]'))


### PR DESCRIPTION
Case CPANEL-46534: Due to changes in the python Message/email package pickles
    created on Python2 don't always work when Python3 tries to access them, so
    we add a small workaround, specifically adding the 'policy' for email
    messages.