### PR TITLE
Fix UnicodeDecodeError error when sending digests

### DIFF
--- a/Mailman/Handlers/Scrubber.py
+++ b/Mailman/Handlers/Scrubber.py
@@ -531,8 +531,24 @@ def save_attachment(mlist, msg, dir, filter_html=True):
     # Is it a message/rfc822 attachment?
     elif ctype == 'message/rfc822':
         submsg = msg.get_payload()
+
+        # submsg is usually a list containing a single Message object.
+        # We need to extract that Message object. (taken from Utils.websafe())
+        if isinstance(submsg, list) or isinstance(submsg, tuple):
+            if len(submsg) == 0:
+                submsg = ''
+            else:
+                submsg = submsg[-1]
+
         # BAW: I'm sure we can eventually do better than this. :(
         decodedpayload = Utils.websafe(str(submsg))
+
+        # encode the message back into the charset of the original message.
+        mcset = submsg.get_content_charset('')
+        if mcset == None or mcset == "":
+            mcset = 'utf-8'
+        decodedpayload = decodedpayload.encode(mcset)
+
     fp = open(path, 'wb')
     fp.write(decodedpayload)
     fp.close()

--- a/Mailman/Handlers/ToDigest.py
+++ b/Mailman/Handlers/ToDigest.py
@@ -361,13 +361,13 @@ def send_i18n_digests(mlist, mboxfp):
         payload = msg.get_payload(decode=True)
         if payload == None:
             payload = msg.as_string().split('\n\n',1)[1]
-        else:
-            payload = str(payload, 'utf-8')
-
+        mcset = msg.get_content_charset('')
+        if mcset == None or mcset == "":
+            mcset = 'utf-8'
+        if isinstance(payload, bytes):
+            payload = payload.decode(mcset, 'replace')
         print(payload, file=plainmsg)
-        if isinstance(payload, str):
-            payload = payload.encode('utf-8')
-        if not payload.endswith(b'\n'):
+        if not payload.endswith('\n'):
             print(file=plainmsg)
 
     # Now add the footer but only if more than whitespace.

--- a/Mailman/MailList.py
+++ b/Mailman/MailList.py
@@ -1123,8 +1123,11 @@ class MailList(HTMLFormatter, Deliverer, ListAdmin,
                 subject = _('%(realname)s subscription notification')
             finally:
                 i18n.set_translation(otrans)
-            if isinstance(name, str):
-                name = name.encode(Utils.GetCharSet(lang), 'replace')
+
+            # The formataddr() function takes a str and performs its own encoding, so we should not allow the name to be pre-encoded
+            if isinstance(name, bytes):
+                name = name.decode(Utils.GetCharSet(lang))
+
             text = Utils.maketext(
                 "adminsubscribeack.txt",
                 {"listname" : realname,


### PR DESCRIPTION
Case CPANEL-46529

If a digest contained a message that had non-utf8 characters, sending the digest would fail with a UnicodeDecodeError. We now check the messages characterset and use that to decode the message into a string.