### PR TITLE
CPANEL-46551

### DIFF
--- a/Mailman/MailList.py
+++ b/Mailman/MailList.py
@@ -1123,8 +1123,11 @@ class MailList(HTMLFormatter, Deliverer, ListAdmin,
                 subject = _('%(realname)s subscription notification')
             finally:
                 i18n.set_translation(otrans)
-            if isinstance(name, str):
-                name = name.encode(Utils.GetCharSet(lang), 'replace')
+
+            # The formataddr() function takes a str and performs its own encoding, so we should not allow the name to be pre-encoded
+            if isinstance(name, bytes):
+                name = name.decode(Utils.GetCharSet(lang))
+
             text = Utils.maketext(
                 "adminsubscribeack.txt",
                 {"listname" : realname,


### PR DESCRIPTION
Decode rather than encoding before sending adminsubscribeack.txt email. Previously, an effort was made to encode the member's name in the appropriate charset before passing it to formataddr(). Now, this is wrong, and we actually need to ensure that it is *not* encoded yet. What gets passed into formataddr() must be str, not bytes.

It's possible for name to be either str or bytes depending on which version of Mailman + Python saved the info to disk previously, so we still need to check which it is before attempting to decode. This only applies to 'nameu' because 'email' never got this special encoding treatment.