### PR TITLE
Make sure IDs are integers for sort

### DIFF
--- a/Mailman/ListAdmin.py
+++ b/Mailman/ListAdmin.py
@@ -134,7 +134,7 @@ class ListAdmin(object):
     def __getmsgids(self, rtype):
         self.__opendb()
         ids = [k for k, (op, data) in list(self.__db.items()) if op == rtype]
-        ids.sort()
+        ids.sort(key=int)
         return ids
 
     def GetHeldMessageIds(self):


### PR DESCRIPTION
Case CPANEL-46609:
It seems the IDs can sometimes become strings when roundtripped to-from the pickle file. This casts the IDs to strings during the sort to avoid the error.