### PR TITLE
Cpanel 46545

### DIFF
--- a/Mailman/Handlers/CookHeaders.py
+++ b/Mailman/Handlers/CookHeaders.py
@@ -443,6 +443,8 @@ def prefix_subject(mlist, msg, msgdata):
         subject = _('(no subject)')
         i18n.set_translation(otrans)
         cset = Utils.GetCharSet(mlist.preferred_language)
+        if isinstance(subject, str):
+            subject = subject.encode()
         subject = str(subject, cset)
     # and substitute %d in prefix with post_id
     try:

--- a/Mailman/Handlers/Decorate.py
+++ b/Mailman/Handlers/Decorate.py
@@ -18,6 +18,7 @@
 """Decorate a message by sticking the header and footer around it."""
 
 from builtins import str
+import codecs
 import re
 
 from email.mime.text import MIMEText
@@ -102,9 +103,11 @@ def process(mlist, msg, msgdata):
         else:
             ufooter = str(footer, lcset, 'ignore')
         try:
-            oldpayload = msg.get_payload()
+            oldpayload = msg.get_payload(decode=True)
             if isinstance(oldpayload, bytes):
-                oldpayload.decode()
+                oldpayload = oldpayload.decode(encoding=mcset)
+            if Utils.needs_unicode_escape_decode(oldpayload):
+                oldpayload = codecs.decode(oldpayload, 'unicode_escape')
             frontsep = endsep = u''
             if header and not header.endswith('\n'):
                 frontsep = u'\n'

--- a/Mailman/Utils.py
+++ b/Mailman/Utils.py
@@ -125,6 +125,12 @@ def list_names():
     return Site.get_listnames()
 
 
+def needs_unicode_escape_decode(s):
+    # Check for Unicode escape patterns (\uXXXX or \UXXXXXXXX)
+    unicode_escape_pattern = re.compile(r'\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}')
+    return bool(unicode_escape_pattern.search(s))
+
+
 
 # a much more naive implementation than say, Emacs's fill-paragraph!
 def wrap(text, column=70, honor_leading_ws=True):


### PR DESCRIPTION
This change contains fixes for three issues:

1. sending a message with an empty subject would result in the message being shunted and exception in the error log
2. sending a non-ascii message in `Content-Transfer-Encoding: base64` would result in a garbled message
3. sending a non-ascii message in `Content-Transfer-Encoding: 8bit` would result in a garbled message if the text was in unicode escape format