### PR TITLE
Filter out email headers that are not strings.

### DIFF
--- a/Mailman/Handlers/Cleanse.py
+++ b/Mailman/Handlers/Cleanse.py
@@ -97,3 +97,8 @@ def process(mlist, msg, msgdata):
     del msg['x-confirm-reading-to']
     # Pegasus mail uses this one... sigh
     del msg['x-pmrqc']
+
+    # Remove any header whose value is not a string.
+    for h, v in list(msg.items()):
+        if not isinstance(v, str):
+            del msg[h]

--- a/Mailman/Handlers/SpamDetect.py
+++ b/Mailman/Handlers/SpamDetect.py
@@ -73,7 +73,10 @@ def getDecodedHeaders(msg, cset='utf-8'):
     for h, v in list(msg.items()):
         uvalue = u''
         try:
-            v = decode_header(re.sub('\n\s', ' ', v))
+            if isinstance(v, str):
+                v = decode_header(re.sub('\n\s', ' ', v))
+            else:
+                continue
         except HeaderParseError:
             v = [(v, 'us-ascii')]
         for frag, cs in v:


### PR DESCRIPTION
Case CPANEL-47096

In some rare cases Mailman was pickling messages with a python object as a header value. If we encounter this situation, we now ignore the header in the SpamDetect handler and remove the header in the Cleanse handler.

Changelog: Filter out email headers that are not strings.