### PR TITLE
Fix bug calling Utils.load_pickle preventing list signups

### DIFF
--- a/Mailman/Pending.py
+++ b/Mailman/Pending.py
@@ -84,7 +84,7 @@ class Pending(object):
 
     def __load(self):
         try:
-            obj = Utils.load_pickle(self.__pendfile)
+            obj = load_pickle(self.__pendfile)
             if obj == None:
                 return {'evictions': {}}
             else:


### PR DESCRIPTION
Case CPANEL-47240: Fix bug calling Utils.load_pickle preventing list signups.
	Utils itself is not fully imported, so the namespace is not used when
	calling load_pickle like it is in most other cases.

Changelog: Fix bug calling Utils.load_pickle preventing list signups